### PR TITLE
API Refactor into monad stack

### DIFF
--- a/examples/GetChannels.hs
+++ b/examples/GetChannels.hs
@@ -7,7 +7,7 @@ import           Network.Connection
 import           System.Process ( readProcess )
 import           Data.Aeson
 import           Data.Foldable
-import           Control.Monad ( when )
+import           Control.Monad ( void, when )
 
 import           Network.Mattermost
 
@@ -29,14 +29,14 @@ main = do
                     , password = T.pack pass
                     , teamname = T.pack team }
 
-  (token, _) <- mmLogin cd login
-  putStrLn ("Authenticated: " ++ show token)
+  void $ runMM cd $ do
+    (token, _) <- mmLogin login
+    io $ putStrLn ("Authenticated: " ++ show token)
 
-  (_,Just body) <- mmGetTeams cd token
-  let Success (TL teamList) = fromJSON body :: Result TeamList
-  forM_ teamList $ \t -> do
-    when (teamName t == team) $ do
-      (hdrs,body) <- mmGetChannels cd token t
-      print (teamName t)
-      print (hdrs,body)
-
+    (_, Just body) <- mmGetTeams
+    let Success (TL teamList) = fromJSON body
+    forM_ teamList $ \t -> do
+      when (teamName t == team) $ do
+        (hdrs,body) <- mmGetChannels t
+        io $ print (teamName t)
+        io $ print (hdrs,body)

--- a/examples/GetTeams.hs
+++ b/examples/GetTeams.hs
@@ -1,6 +1,7 @@
 -- Use this module via `cabal repl` and then :load examples/GetTeams.hs
 -- You will need to fill out your username, hostname, and password
 module Main (main) where
+import           Control.Monad ( void )
 import qualified Data.Text as T
 import           Network.Connection
 import           System.Process ( readProcess )
@@ -25,9 +26,8 @@ main = do
                     , password = T.pack pass
                     , teamname = T.pack team }
 
-  (token, _) <- mmLogin cd login
-  putStrLn ("Authenticated: " ++ show token)
-
-  r <- mmGetTeams cd token
-  print r
-
+  void $ runMM cd $ do
+    (token, _) <- mmLogin login
+    io $ putStrLn ("Authenticated: " ++ show token)
+    r <- mmGetTeams
+    io $ print r

--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -12,6 +12,10 @@ build-type:          Simple
 extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
+flag build-examples
+  description: Build example applications
+  default:     False
+
 library
   exposed-modules:     Network.Mattermost
                      , Network.Mattermost.WebSocket.Types
@@ -34,3 +38,29 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:       -Wall
+
+executable mm-get-teams
+  if !flag(build-examples)
+    buildable: False
+  default-language: Haskell2010
+  main-is:          GetTeams.hs
+  hs-source-dirs:   examples
+  build-depends:    base
+                  , mattermost-api
+                  , aeson
+                  , text
+                  , connection
+                  , process
+
+executable mm-get-channels
+  if !flag(build-examples)
+    buildable:        False
+  default-language: Haskell2010
+  main-is:          GetChannels.hs
+  hs-source-dirs:   examples
+  build-depends:    base
+                  , mattermost-api
+                  , aeson
+                  , text
+                  , connection
+                  , process

--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -14,8 +14,9 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Network.Mattermost
-  -- other-modules:       
-  -- other-extensions:    
+                     , Network.Mattermost.WebSocket.Types
+  -- other-modules:
+  -- other-extensions:
   build-depends:       base >=4.8 && <4.9
                      , websockets
                      , aeson
@@ -29,4 +30,3 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:       -Wall
-

--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Network.Mattermost
                      , Network.Mattermost.WebSocket.Types
-  -- other-modules:
+  other-modules:       Network.Mattermost.Util
+                     , Network.Mattermost.Types
   -- other-extensions:
   build-depends:       base >=4.8 && <4.9
                      , websockets
@@ -29,6 +30,7 @@ library
                      , text
                      , time
                      , unordered-containers
+                     , mtl
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:       -Wall

--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -14,6 +14,8 @@ module Network.Mattermost
 , mmLogin
 , mmGetTeams
 , mmGetChannels
+, runMM
+, io
 ) where
 
 import           Data.Default ( def )

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -1,7 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Network.Mattermost.Types where
 
-import Network.Connection (ConnectionContext)
-import Network.HTTP.Headers (Header, HeaderName(..), mkHeader)
+import qualified Data.Aeson as A
+import qualified Data.HashMap.Strict as HM
+import           Data.Ratio ( (%) )
+import qualified Data.Text as T
+import           Data.Time.Clock ( UTCTime )
+import           Data.Time.Clock.POSIX ( posixSecondsToUTCTime )
+import           Network.Connection (ConnectionContext)
+import           Network.HTTP.Headers (Header, HeaderName(..), mkHeader)
 
 type Hostname = String
 type Port     = Int
@@ -43,3 +51,88 @@ data Token = Token String
 
 getTokenString :: Token -> String
 getTokenString (Token s) = s
+
+--
+
+data Login
+  = Login
+  { username :: T.Text
+  , teamname :: T.Text
+  , password :: T.Text
+  }
+
+instance A.ToJSON Login where
+  toJSON l = A.object ["name"     A..= teamname l
+                      ,"login_id" A..= username l
+                      ,"password" A..= password l
+                      ]
+
+
+-- | XXX: No idea what this is
+data TeamType = O | Unknown
+  deriving (Read, Show, Ord, Eq)
+
+instance A.FromJSON TeamType where
+  parseJSON (A.String "O") = pure O
+  parseJSON _              = pure Unknown
+
+--
+
+newtype Id = Id T.Text
+  deriving (Read, Show, Eq, Ord)
+
+instance A.FromJSON Id where
+  parseJSON = A.withText "Id" $ \s ->
+    pure (Id s)
+
+--
+
+getTeamIdString :: Team -> String
+getTeamIdString team = case teamId team of
+  Id s -> T.unpack s
+
+data Team
+  = Team
+  { teamId              :: Id
+  , teamCreateAt        :: UTCTime
+  , teamUpdateAt        :: UTCTime
+  , teamDeleteAt        :: UTCTime
+  , teamDisplayName     :: String
+  , teamName            :: String
+  , teamEmail           :: String
+  , teamType            :: TeamType
+  , teamCompanyName     :: String
+  , teamAllowedDomains  :: String
+  , teamInviteId        :: Id
+  , teamAllowOpenInvite :: Bool
+  }
+  deriving (Read, Show, Eq, Ord)
+
+instance A.FromJSON Team where
+  parseJSON = A.withObject "Team" $ \v -> Team     <$>
+    v A..: "id"                                    <*>
+    (millisecondsToUTCTime <$> v A..: "create_at") <*>
+    (millisecondsToUTCTime <$> v A..: "update_at") <*>
+    (millisecondsToUTCTime <$> v A..: "delete_at") <*>
+    v A..: "display_name"                          <*>
+    v A..: "name"                                  <*>
+    v A..: "email"                                 <*>
+    v A..: "type"                                  <*>
+    v A..: "company_name"                          <*>
+    v A..: "allowed_domains"                       <*>
+    v A..: "invite_id"                             <*>
+    v A..: "allow_open_invite"
+
+millisecondsToUTCTime :: Integer -> UTCTime
+millisecondsToUTCTime ms = posixSecondsToUTCTime (fromRational (ms%1000))
+
+--
+
+newtype TeamList = TL [Team]
+  deriving (Read, Show, Eq, Ord)
+
+instance A.FromJSON TeamList where
+  parseJSON = A.withObject "TeamList" $ \hm -> do
+    let tl = map snd (HM.toList hm)
+    tl' <- mapM A.parseJSON tl
+    return (TL tl')

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -1,0 +1,45 @@
+module Network.Mattermost.Types where
+
+import Network.Connection (ConnectionContext)
+import Network.HTTP.Headers (Header, HeaderName(..), mkHeader)
+
+type Hostname = String
+type Port     = Int
+
+-- For now we don't support or expose the ability to reuse connections,
+-- but we have this field in case we want to support that in the future.
+-- Doing so will require some modifications to withConnection (and uses).
+-- Note: don't export this until we support connection reuse.
+data AutoClose = No | Yes
+  deriving (Read, Show, Eq, Ord)
+
+-- | We return a list of headers so that we can treat
+-- the headers like a monoid.
+autoCloseToHeader :: AutoClose -> [Header]
+autoCloseToHeader No  = []
+autoCloseToHeader Yes = [mkHeader HdrConnection "Close"]
+
+
+data ConnectionData
+  = ConnectionData
+  { cdHostname      :: Hostname
+  , cdPort          :: Port
+  , cdAutoClose     :: AutoClose
+  , cdConnectionCtx :: ConnectionContext
+  , cdToken         :: Maybe Token
+  }
+
+mkConnectionData :: Hostname -> Port -> ConnectionContext -> ConnectionData
+mkConnectionData host port ctx = ConnectionData
+  { cdHostname      = host
+  , cdPort          = port
+  , cdConnectionCtx = ctx
+  , cdAutoClose     = Yes
+  , cdToken         = Nothing
+  }
+
+data Token = Token String
+  deriving (Read, Show, Eq, Ord)
+
+getTokenString :: Token -> String
+getTokenString (Token s) = s

--- a/src/Network/Mattermost/Util.hs
+++ b/src/Network/Mattermost/Util.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Network.Mattermost.Util where
+
+import Control.Monad.Except
+import Control.Monad.State.Strict
+
+import Network.Mattermost.Types
+
+-- A convenient, internal wrapper for IO actions that might fail.
+newtype MM a = MM (ExceptT String (StateT ConnectionData IO) a)
+  deriving (Functor, Applicative, Monad, MonadError String, MonadIO)
+
+-- Lift an IO action into the MM monad
+io :: IO a -> MM a
+io = liftIO
+
+-- Lift an IO action that produces an Either String into the MM monad
+ioE :: IO (Either String a) -> MM a
+ioE mote = do
+  v <- io mote
+  case v of
+    Left  l -> throwError l
+    Right r -> pure r
+
+-- Lift an IO action that produces an Either s into the MM monad,
+-- indicating what to do with the Left value to turn it into a
+-- string
+ioS :: (s -> String) -> IO (Either s a) -> MM a
+ioS f mote = do
+  v <- io mote
+  case v of
+    Left  l -> throwError (f l)
+    Right r -> pure r
+
+-- Lift a Maybe into the MM monad, with a supplied error message should
+-- the value be Nothing
+ioM :: String -> IO (Maybe a) -> MM a
+ioM err mote = io mote >>= noteT err
+
+runMM :: ConnectionData -> MM a -> IO (Either String a)
+runMM cd (MM m) = fmap fst (runStateT (runExceptT m) cd)
+
+noteT :: String -> Maybe r -> MM r
+noteT l Nothing  = throwError l
+noteT _ (Just r) = pure r
+
+hoistT :: Either String r -> MM r
+hoistT (Left l)  = throwError l
+hoistT (Right r) = pure r
+
+assert :: String -> Bool -> MM ()
+assert _ True  = pure ()
+assert m False = throwError m
+
+setToken :: Token -> MM ()
+setToken b = MM $ modify $ \cd -> cd { cdToken = Just b }
+
+getToken :: MM Token
+getToken = MM $ do
+  v <- cdToken `fmap` get
+  case v of
+    Nothing -> throwError "No token currently set!"
+    Just x  -> pure x
+
+getConnectionData :: MM ConnectionData
+getConnectionData = MM get

--- a/src/Network/Mattermost/WebSocket/Types.hs
+++ b/src/Network/Mattermost/WebSocket/Types.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.Mattermost.WebSocket.Types where
+
+import           Data.Aeson (Object, FromJSON(..), ToJSON(..), (.:), (.=))
+import qualified Data.Aeson as A
+import           Data.Text (Text)
+
+data WebsocketEventType
+  = WMTyping
+  | WMPosted
+  | WMPostEdited
+  | WMPostDeleted
+  | WMChannelDeleted
+  | WMChannelViewed
+  | WMDirectAdded
+  | WMNewUser
+  | WMLeaveTeam
+  | WMUserAdded
+  | WMUserRemoved
+  | WMPreferenceChanged
+  | WMEphemeralMessage
+  | WMStatusChange
+    deriving (Read, Show, Eq, Ord)
+
+instance FromJSON WebsocketEventType where
+  parseJSON = A.withText "event type" $ \s -> case s of
+    "typing"             -> pure WMTyping
+    "posted"             -> pure WMPosted
+    "post_edited"        -> pure WMPostEdited
+    "post_deleted"       -> pure WMPostDeleted
+    "channel_deleted"    -> pure WMChannelDeleted
+    "channel_viewed"     -> pure WMChannelViewed
+    "direct_added"       -> pure WMDirectAdded
+    "new_user"           -> pure WMNewUser
+    "leave_team"         -> pure WMLeaveTeam
+    "user_added"         -> pure WMUserAdded
+    "user_removed"       -> pure WMUserRemoved
+    "preference_changed" -> pure WMPreferenceChanged
+    "ephemeral_message"  -> pure WMEphemeralMessage
+    "status_change"      -> pure WMStatusChange
+    _                    -> fail ("Unknown websocket message: " ++ show s)
+
+instance ToJSON WebsocketEventType where
+  toJSON WMTyping            = "typing"
+  toJSON WMPosted            = "posted"
+  toJSON WMPostEdited        = "post_edited"
+  toJSON WMPostDeleted       = "post_deleted"
+  toJSON WMChannelDeleted    = "channel_deleted"
+  toJSON WMChannelViewed     = "channel_viewed"
+  toJSON WMDirectAdded       = "direct_added"
+  toJSON WMNewUser           = "new_user"
+  toJSON WMLeaveTeam         = "leave_team"
+  toJSON WMUserAdded         = "user_added"
+  toJSON WMUserRemoved       = "user_removed"
+  toJSON WMPreferenceChanged = "preference_changed"
+  toJSON WMEphemeralMessage  = "ephemeral_message"
+  toJSON WMStatusChange      = "status_change"
+
+--
+
+data WebsocketEvent = WebsocketEvent
+  { weEvent     :: WebsocketEventType
+  , weTeamId    :: Text
+  , weChannelId :: Text
+  , weUserId    :: Text
+  , weData      :: Object
+  } deriving (Read, Show, Eq)
+
+instance FromJSON WebsocketEvent where
+  parseJSON = A.withObject "websocket event" $ \o ->
+    WebsocketEvent <$> o .: "event"
+                   <*> o .: "team_id"
+                   <*> o .: "channel_id"
+                   <*> o .: "user_id"
+                   <*> o .: "data"
+
+instance ToJSON WebsocketEvent where
+  toJSON we = A.object
+    [ "event"      .= weEvent we
+    , "team_id"    .= weTeamId we
+    , "channel_id" .= weChannelId we
+    , "user_id"    .= weUserId we
+    , "data"       .= weData we
+    ]
+
+--
+
+data WebsocketResponse = WebsocketResponse
+  { wrStatus   :: Text
+  , wrSeqReply :: Maybe Int
+  , wrData     :: Maybe Object
+  , wrError    :: Maybe Text
+  } deriving (Read, Show, Eq)
+
+instance FromJSON WebsocketResponse where
+  parseJSON = A.withObject "websocket response" $ \o ->
+    WebsocketResponse <$> o .: "status"
+                      <*> o .: "seq_reply"
+                      <*> o .: "data"
+                      <*> o .: "error"
+
+instance ToJSON WebsocketResponse where
+  toJSON wr = A.object
+    [ "status"    .= wrStatus wr
+    , "seq_reply" .= wrSeqReply wr
+    , "data"      .= wrData wr
+    , "error"     .= wrError wr
+    ]
+
+--
+
+data WebsocketRequest = WebsocketRequest
+  { wqSeq    :: Int
+  , wqAction :: Text
+  , wqData   :: Object
+  } deriving (Read, Show, Eq)
+
+instance ToJSON WebsocketRequest where
+  toJSON wq = A.object
+    [ "seq"    .= wqSeq wq
+    , "action" .= wqAction wq
+    , "data"   .= wqData wq
+    ]
+
+instance FromJSON WebsocketRequest where
+  parseJSON = A.withObject "websocket request" $ \o ->
+    WebsocketRequest <$> o .: "seq"
+                     <*> o .: "action"
+                     <*> o .: "data"


### PR DESCRIPTION
This wraps up some parameter-passing and error-handling into a `MM` monad, which contains connection state and authentication state as well as handles errors more nicely.

EDIT: also added the examples to the `cabal` file behind a flag called `build-examples`, which defaults to false.
