### PR TITLE
Expose types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Revision history for mattermost-api
 
+30701.2.0
+=========
+
+API changes:
+
+* The `Network.Mattermost.Types` module is now directly exported
+  and all clients should obtain their types from this import.  The
+  types are still exported from `Network.Mattermost` to allow time
+  for this change but this export is deprecated will be removed
+  in a future version.
+
 30701.1.0
 =========
 

--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -1,5 +1,5 @@
 name:                mattermost-api
-version:             30701.1.0
+version:             30701.2.0
 synopsis:            Client API for MatterMost chat system
 description:         Client API for MatterMost chat system
 license:             BSD3
@@ -30,8 +30,8 @@ library
                        Network.Mattermost.WebSocket
                        Network.Mattermost.WebSocket.Types
                        Network.Mattermost.Version
-  other-modules:       Network.Mattermost.Types
-                       Network.Mattermost.TH
+                       Network.Mattermost.Types
+  other-modules:       Network.Mattermost.TH
                        Paths_mattermost_api
   -- other-extensions:
   build-depends:       base >=4.4 && <5

--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -3,7 +3,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Network.Mattermost
 ( -- * Types
-  -- ** Mattermost-Related Types
+  -- ** Mattermost-Related Types (deprecated: use Network.MatterMost.Types instead)
+  -- n.b. the deprecation notice is in that haddock header because we're
+  -- still waiting for https://ghc.haskell.org/trac/ghc/ticket/4879 ...
   Login(..)
 , Hostname
 , Port

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -32,7 +32,6 @@ import           Network.Connection ( Connection
 import qualified Network.WebSockets as WS
 import           Network.WebSockets.Stream (Stream, makeStream)
 
-import           Network.Mattermost
 import           Network.Mattermost.Util
 import           Network.Mattermost.Types
 import           Network.Mattermost.WebSocket.Types

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,7 +17,6 @@ import qualified Data.Sequence as Seq
 
 import           Test.Tasty
 
-import           Network.Mattermost
 import           Network.Mattermost.Types
 import           Network.Mattermost.WebSocket.Types
 import           Network.Mattermost.Exceptions

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,6 +18,7 @@ import qualified Data.Sequence as Seq
 import           Test.Tasty
 
 import           Network.Mattermost
+import           Network.Mattermost.Types
 import           Network.Mattermost.WebSocket.Types
 import           Network.Mattermost.Exceptions
 

--- a/test/Tests/Types.hs
+++ b/test/Tests/Types.hs
@@ -11,6 +11,7 @@ import Control.Concurrent.MVar
 import qualified Control.Concurrent.STM.TChan as STM
 
 import Network.Mattermost
+import Network.Mattermost.Types
 import Network.Mattermost.WebSocket.Types
 
 data Config

--- a/test/Tests/Types.hs
+++ b/test/Tests/Types.hs
@@ -10,7 +10,6 @@ import Control.Monad.State.Lazy
 import Control.Concurrent.MVar
 import qualified Control.Concurrent.STM.TChan as STM
 
-import Network.Mattermost
 import Network.Mattermost.Types
 import Network.Mattermost.WebSocket.Types
 

--- a/test/Tests/Util.hs
+++ b/test/Tests/Util.hs
@@ -60,6 +60,7 @@ import System.Timeout (timeout)
 import qualified Data.HashMap.Lazy as HM
 
 import Network.Mattermost
+import Network.Mattermost.Types
 import Network.Mattermost.WebSocket
 import Network.Mattermost.Exceptions
 


### PR DESCRIPTION
This exposes the types for the api library, which allows QuickCheck instances, among other things.  The types are still exported by `Network.Mattermost` as well to allow for a transition period, but these should be considered deprecated and will be removed in the future.

Presently there are some "unused imports" warnings due to this duplication; these will be resolved once the type exports are removed from `Network.Mattermost`.