### PR TITLE
Correct ChannelData reference

### DIFF
--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -435,7 +435,7 @@ data ChannelData
   } deriving (Read, Show, Eq)
 
 instance A.FromJSON ChannelData where
-  parseJSON = A.withObject "ChanelData" $ \o -> do
+  parseJSON = A.withObject "ChannelData" $ \o -> do
     channelDataChannelId <- o .: "channel_id"
     channelDataUserId    <- o .: "user_id"
     channelDataRoles     <- o .: "roles"


### PR DESCRIPTION
According to https://github.com/matterhorn-chat/mattermost-api-reference/blob/master/v4/source/definitions.yaml#L148 this looks like a mistake on our side.