### PR TITLE
workaround for missing gitlab-auth

### DIFF
--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -236,6 +236,10 @@ mmUnauthenticatedHTTPPost cd path json = do
 --
 -- route: @\/api\/v3\/users\/login@
 mmLogin :: ConnectionData -> Login -> IO (Either LoginFailureException (Session, User))
+mmLogin cd (Login "MMAUTHTOKEN" token) = do
+  let sess = Session cd (Token $ T.unpack token)
+  value <- mmDoRequest sess "mmLogin with MMAUTHTOKEN" "/api/v3/users/me"
+  return (Right (sess, value))
 mmLogin cd login = do
   let rawPath = "/api/v3/users/login"
   path <- mmPath rawPath


### PR DESCRIPTION
This is the code I currently use to connect to one of those "Gitlab Mattermost" thingies. I do not expect this to be merged - it should only serve to solve the chicken-and-egg-problem that nobody using "Gitlab Mattermost" is able to test matterhorn leading to nobody implementing support for their authentication service.

How to use:

1. Use your browser to authenticate to mattermost
2. Somehow get the contents of the `MMAUTHTOKEN` cookie. It is not accessible via JavaScript. (In Chromium: F12, Application, Storage, Cookies)
3. Supply the client of your choice (e.g. matterhorn) with the username `MMAUTHTOKEN` and the authentication token as the password

This might also work with other authentication services.