### PR TITLE
Add support for post search endpoint

### DIFF
--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -81,6 +81,7 @@ module Network.Mattermost
 , mmGetPostsSince
 , mmGetPostsBefore
 , mmGetPostsAfter
+, mmSearchPosts
 , mmGetReactionsForPost
 , mmGetFileInfo
 , mmGetFile
@@ -499,6 +500,25 @@ mmGetPostsBefore sess teamid chanid postid offset limit =
          (idString postid)
          offset
          limit
+
+-- |
+-- route: @\/api\/v4\/teams\/{team_id}\/posts\/search@
+mmSearchPosts :: Session
+              -> TeamId
+              -> T.Text
+              -> Bool
+              -> IO Posts
+mmSearchPosts sess teamid terms isOrSearch = do
+  let path = printf "/api/v4/teams/%s/posts/search" $ idString teamid
+  uri <- mmPath path
+  let req = SearchPosts terms isOrSearch
+  runLoggerS sess "mmSearchPosts" $
+    HttpRequest POST path (Just (toJSON req))
+  rsp <- mmPOST sess uri req
+  (raw, value) <- mmGetJSONBody "SearchPostsResult" rsp
+  runLoggerS sess "mmSearchPosts" $
+    HttpResponse 200 path (Just raw)
+  return value
 
 -- |
 -- route: @\/api\/v3\/files\/{file_id}\/get_info@

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -117,6 +117,17 @@ instance A.ToJSON SetChannelHeader where
                ,"channel_header" A..= p
                ]
 
+data SearchPosts = SearchPosts
+ { searchPostsTerms      :: Text
+ , searchPostsIsOrSearch :: Bool
+ }
+
+instance A.ToJSON SearchPosts where
+ toJSON (SearchPosts t os) =
+     A.object ["terms" A..= t
+              ,"is_or_search" A..= os
+              ]
+
 data Type = Ordinary
           | Direct
           | Private


### PR DESCRIPTION
Adds a `mmSearchPosts` function to call the [post search API endpoint](https://api.mattermost.com/#tag/posts%2Fpaths%2F~1teams~1%7Bteam_id%7D~1posts~1search%2Fpost) which returns a list of `Posts`.
The function will be called by the TUI to support searching posts. The relevant issue is [here](https://github.com/matterhorn-chat/matterhorn/issues/328).