### PR TITLE
Add client configuration API

### DIFF
--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -105,6 +105,7 @@ module Network.Mattermost
 , mmUpdatePost
 , mmExecute
 , mmGetConfig
+, mmGetClientConfig
 , mmSetPreferences
 , mmSavePreferences
 , mmDeletePreferences
@@ -720,6 +721,16 @@ mmGetConfig :: Session
             -> IO Value
 mmGetConfig sess =
   mmDoRequest sess "mmGetConfig" "/api/v3/admin/config"
+
+-- | Get a subset of the server configuration needed by the client. Does not
+-- require administrative permission. The format query parameter is currently
+-- required with the value of "old".
+--
+-- route: @\/api\/v4\/config\/client@
+mmGetClientConfig :: Session
+                  -> IO Value
+mmGetClientConfig sess =
+  mmDoRequest sess "mmGetClientConfig" "/api/v4/config/client?format=old"
 
 mmSaveConfig :: Session
              -> Value

--- a/test/Tests/Util.hs
+++ b/test/Tests/Util.hs
@@ -13,6 +13,7 @@ module Tests.Util
   , getChannelMembers
   , getUserByName
   , getConfig
+  , getClientConfig
   , saveConfig
   , teamAddUser
   , reportJSONExceptions
@@ -382,6 +383,11 @@ getConfig :: TestM A.Value
 getConfig = do
   session <- getSession
   liftIO $ mmGetConfig session
+
+getClientConfig :: TestM A.Value
+getClientConfig = do
+  session <- getSession
+  liftIO $ mmGetClientConfig session
 
 saveConfig :: A.Value -> TestM ()
 saveConfig newConfig = do


### PR DESCRIPTION
Add mmGetClientConfig function to request the client configuration
from the mattermost server. This API is only available in version 4 of
the mattermost API.

Also add a test case to verify the presence of a sampling of keys from 
the client configuration payload. I plan to use this change to finish up 
the work to add nickname support to matterhorn so the key I am most 
interested in is `TeammateNameDisplay`. I did not include that key in 
the test case because unfortunately it is the case that the client 
configuration API only included that key as of the 4.0 mattermost 
server release and the test cases currently run against the 3.8 release 
of the server.