### PR TITLE
Add websocket action support

### DIFF
--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -7,6 +7,7 @@ module Network.Mattermost.WebSocket
 , MMWebSocketTimeoutException
 , mmWithWebSocket
 , mmCloseWebSocket
+, mmSendWSAction
 , mmGetConnectionHealth
 , module Network.Mattermost.WebSocket.Types
 ) where
@@ -142,3 +143,8 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
         propagate ts e = do
           sequence_ [ throwTo t e | t <- ts ]
           throwIO e
+
+mmSendWSAction :: ConnectionData -> MMWebSocket -> WebsocketAction -> IO ()
+mmSendWSAction cd (MMWS ws _) a = do
+  runLogger cd "websocket" $ WebSocketRequest $ toJSON a
+  WS.sendTextData ws a

--- a/src/Network/Mattermost/WebSocket/Types.hs
+++ b/src/Network/Mattermost/WebSocket/Types.hs
@@ -7,6 +7,7 @@ module Network.Mattermost.WebSocket.Types
 , WebsocketEvent(..)
 , WEData(..)
 , WEBroadcast(..)
+, WebsocketAction(..)
 ) where
 
 import           Control.Applicative
@@ -255,3 +256,29 @@ instance ToJSON WEBroadcast where
     , "user_id"    .= webUserId
     , "omit_users" .= webOmitUsers
     ]
+
+--
+
+data WebsocketAction =
+    UserTyping { waSeq          :: Int64
+               , waChannelId    :: ChannelId
+               , waParentPostId :: Maybe PostId
+               }
+  -- | GetStatuses { waSeq :: Int64 }
+  -- | GetStatusesByIds { waSeq :: Int64, waUserIds :: [UserId] }
+  deriving (Read, Show, Eq, Ord)
+
+instance ToJSON WebsocketAction where
+  toJSON (UserTyping s cId pId) = A.object
+    [ "seq"    .= s
+    , "action" .= T.pack "user_typing"
+    , "data"   .= A.object
+                  [ "channel_id" .= unId (toId cId)
+                  , "parent_id"  .= maybe "" (unId . toId) pId
+                  ]
+    ]
+
+instance WebSocketsData WebsocketAction where
+  fromDataMessage _ = error "Not implemented"
+  fromLazyByteString _ = error "Not implemented"
+  toLazyByteString = A.encode


### PR DESCRIPTION
- Adds websocket action type. For now only user_typing action is implemented.
- Adds mmSendWSAction function to send a websocket action to the server.
- This is required for https://github.com/matterhorn-chat/matterhorn/pull/344