### PR TITLE
Add connection pooling for HTTP connections

### DIFF
--- a/examples/GetChannels.hs
+++ b/examples/GetChannels.hs
@@ -19,9 +19,8 @@ import           LocalConfig -- You will need to define a function:
 main :: IO ()
 main = do
   config <- getConfig -- see LocalConfig import
-  ctx    <- initConnectionContext
-  let cd = mkConnectionData (configHostname config)
-                            (fromIntegral (configPort config)) ctx
+  cd <- initConnectionData (configHostname config)
+                           (fromIntegral (configPort config)) defaultConnectionPoolConfig
 
   let login = Login { username = configUsername config
                     , password = configPassword config

--- a/examples/GetPosts.hs
+++ b/examples/GetPosts.hs
@@ -97,13 +97,11 @@ main = do
   opts <- foldl (>>=) (return defaultOptions) actions
 
   config <- getConfig -- see LocalConfig import
-  ctx    <- initConnectionContext
-  let cd'      = mkConnectionData (configHostname config)
-                                 (fromIntegral (configPort config))
-                                 ctx
-      login   = Login { username = configUsername config
-                      , password = configPassword config
-                      }
+  cd'    <- initConnectionData (configHostname config) (fromIntegral (configPort config))
+                               defaultConnectionPoolConfig
+  let login = Login { username = configUsername config
+                    , password = configPassword config
+                    }
       cd = if optLogging opts
              then cd' `withLogger` mmLoggerDebugErr
              else cd'

--- a/examples/GetTeams.hs
+++ b/examples/GetTeams.hs
@@ -16,10 +16,9 @@ import           LocalConfig -- You will need to define a function:
 main :: IO ()
 main = do
   config <- getConfig -- see LocalConfig import
-  ctx    <- initConnectionContext
-  let cd = mkConnectionData (configHostname config)
-                            (fromIntegral (configPort config))
-                            ctx
+  cd <- initConnectionData (configHostname config) (fromIntegral (configPort config))
+                           defaultConnectionPoolConfig
+
   let login = Login { username = configUsername config
                     , password = configPassword config
                     }

--- a/examples/GetWebsocketConnection.hs
+++ b/examples/GetWebsocketConnection.hs
@@ -53,13 +53,12 @@ main = do
   opts <- foldl (>>=) (return defaultOptions) actions
 
   config <- getConfig -- see LocalConfig import
-  ctx    <- initConnectionContext
-  let cd      = mkConnectionData (configHostname config)
-                                 (fromIntegral (configPort config))
-                                 ctx
-      login   = Login { username = configUsername config
-                      , password = configPassword config
-                      }
+  cd <- initConnectionData (configHostname config) (fromIntegral (configPort config))
+                           defaultConnectionPoolConfig
+
+  let login = Login { username = configUsername config
+                    , password = configPassword config
+                    }
 
   (session, mmUser) <- join (hoistE <$> mmLogin cd login)
   when (optVerbose opts) $ do

--- a/examples/MakePost.hs
+++ b/examples/MakePost.hs
@@ -73,13 +73,12 @@ main = do
   opts <- foldl (>>=) (return defaultOptions) actions
 
   config <- getConfig -- see LocalConfig import
-  ctx    <- initConnectionContext
-  let cd      = mkConnectionData (configHostname config)
-                                 (fromIntegral (configPort config))
-                                 ctx
-      login   = Login { username = configUsername config
-                      , password = configPassword config
-                      }
+  cd <- initConnectionData (configHostname config) (fromIntegral (configPort config))
+                           defaultConnectionPoolConfig
+
+  let login = Login { username = configUsername config
+                    , password = configPassword config
+                    }
 
   (session, mmUser) <- join (hoistE <$> mmLogin cd login)
   when (optVerbose opts) $ do

--- a/examples/ShowEvents.hs
+++ b/examples/ShowEvents.hs
@@ -82,13 +82,12 @@ main = do
 
   config <- getConfig -- see LocalConfig import
   let repl = do
-        ctx    <- initConnectionContext
-        let cd      = mkConnectionData (T.unpack (configHostname config))
-                                       (fromIntegral (configPort config))
-                                       ctx
-            login   = Login { username = configUsername config
-                            , password = configPassword config
-                            }
+        cd <- initConnectionData (configHostname config) (fromIntegral (configPort config))
+                                 defaultConnectionPoolConfig
+
+        let login = Login { username = configUsername config
+                          , password = configPassword config
+                          }
 
         (token, mmUser) <- join (hoistE <$> mmLogin cd login)
         when (optVerbose opts) $ do

--- a/examples/ShowRawEvents.hs
+++ b/examples/ShowRawEvents.hs
@@ -63,13 +63,12 @@ main = do
   opts <- foldl (>>=) (return defaultOptions) actions
 
   config <- getConfig -- see LocalConfig import
-  ctx    <- initConnectionContext
-  let cd      = mkConnectionData (configHostname config)
-                  (fromIntegral (configPort config))
-                  ctx
-      login   = Login { username = configUsername config
-                      , password = configPassword config
-                      }
+  cd     <- initConnectionData (configHostname config) (fromIntegral (configPort config))
+                               defaultConnectionPoolConfig
+
+  let login = Login { username = configUsername config
+                    , password = configPassword config
+                    }
 
   (session, mmUser) <- join (hoistE <$> mmLogin cd login)
   when (optVerbose opts) $ do

--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -42,7 +42,7 @@ library
                      , aeson >= 1.0.0.0
                      , connection
                      , memory <0.14.3
-                     , resource-pool
+                     , resource-pool >= 0.2.3
                      -- To prevent broken websockets versions from using
                      -- incompatible versions of binary (for details, see
                      -- https://github.com/matterhorn-chat/mattermost-api/issues/36):

--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -42,6 +42,7 @@ library
                      , aeson >= 1.0.0.0
                      , connection
                      , memory <0.14.3
+                     , resource-pool
                      -- To prevent broken websockets versions from using
                      -- incompatible versions of binary (for details, see
                      -- https://github.com/matterhorn-chat/mattermost-api/issues/36):

--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -7,7 +7,8 @@ module Network.Mattermost
   -- ** Mattermost-Related Types (deprecated: use Network.Mattermost.Types instead)
   -- n.b. the deprecation notice is in that haddock header because we're
   -- still waiting for https://ghc.haskell.org/trac/ghc/ticket/4879 ...
-  Login(..)
+  ConnectionPoolConfig(..)
+, Login(..)
 , Hostname
 , Port
 , ConnectionData
@@ -56,6 +57,7 @@ module Network.Mattermost
 -- * Typeclasses
 , HasId(..)
 -- * HTTP API Functions
+, defaultConnectionPoolConfig
 , mkConnectionData
 , initConnectionData
 , initConnectionDataInsecure

--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -59,6 +59,7 @@ module Network.Mattermost
 , mkConnectionData
 , initConnectionData
 , initConnectionDataInsecure
+, mmCloseSession
 , mmLogin
 , mmCreateDirect
 , mmCreateChannel
@@ -1096,3 +1097,6 @@ assert200Response path rsp =
                         in throwIO $ MattermostServerError newMsg
                     _ -> throwIO $ httpExc
             _ -> throwIO $ httpExc
+
+mmCloseSession :: Session -> IO ()
+mmCloseSession (Session cd _) = destroyConnectionData cd

--- a/src/Network/Mattermost/Types/Internal.hs
+++ b/src/Network/Mattermost/Types/Internal.hs
@@ -7,7 +7,8 @@
 
 module Network.Mattermost.Types.Internal where
 
-import Network.Connection (ConnectionContext)
+import Data.Pool (Pool)
+import Network.Connection (ConnectionContext, Connection)
 import Network.HTTP.Headers (Header, HeaderName(..), mkHeader)
 import Network.Mattermost.Types.Base
 
@@ -17,10 +18,6 @@ data Token = Token String
 getTokenString :: Token -> String
 getTokenString (Token s) = s
 
--- For now we don't support or expose the ability to reuse connections,
--- but we have this field in case we want to support that in the future.
--- Doing so will require some modifications to withConnection (and uses).
--- Note: don't export this until we support connection reuse.
 data AutoClose = No | Yes
   deriving (Read, Show, Eq, Ord)
 
@@ -33,11 +30,12 @@ autoCloseToHeader Yes = [mkHeader HdrConnection "Close"]
 
 data ConnectionData
   = ConnectionData
-  { cdHostname      :: Hostname
-  , cdPort          :: Port
-  , cdAutoClose     :: AutoClose
-  , cdConnectionCtx :: ConnectionContext
-  , cdToken         :: Maybe Token
-  , cdLogger        :: Maybe Logger
-  , cdUseTLS        :: Bool
+  { cdHostname       :: Hostname
+  , cdPort           :: Port
+  , cdAutoClose      :: AutoClose
+  , cdConnectionPool :: Pool Connection
+  , cdConnectionCtx  :: ConnectionContext
+  , cdToken          :: Maybe Token
+  , cdLogger         :: Maybe Logger
+  , cdUseTLS         :: Bool
   }

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -110,7 +110,7 @@ mmWithWebSocket :: Session
                 -> (MMWebSocket -> IO ())
                 -> IO ()
 mmWithWebSocket (Session cd (Token tk)) recv body = do
-  con <- mkConnection cd
+  con <- mkConnection (cdConnectionCtx cd) (cdHostname cd) (cdPort cd) (cdUseTLS cd)
   stream <- connectionToStream con
   health <- newIORef 0
   myId <- myThreadId

--- a/test/Tests/Util.hs
+++ b/test/Tests/Util.hs
@@ -310,8 +310,8 @@ findChannel chans name =
 
 connectFromConfig :: Config -> IO ConnectionData
 connectFromConfig cfg =
-  initConnectionDataInsecure (configHostname cfg)
-                             (fromIntegral (configPort cfg))
+  initConnectionDataInsecure (configHostname cfg) (fromIntegral (configPort cfg))
+                             defaultConnectionPoolConfig
 
 getConnection :: TestM ConnectionData
 getConnection = gets tsConnectionData


### PR DESCRIPTION
- connection pool is kept in the ConnectionData data.
- initConnectionData(Secure) take ConnectionPoolConfig as a parameter now.
- withConnection function now ges the connection from the pool instead of creating a new connection each time
- sets AutoClose to `No`
- added mmCloseSession function which closes the connection pool

Fixes issue #43.