### PR TITLE
Fix examples to use the UserText type instead of Data.Text

### DIFF
--- a/examples/Config.hs
+++ b/examples/Config.hs
@@ -1,12 +1,13 @@
 module Config where
 
 import Data.Text
+import Network.Mattermost.Types ( UserText )
 
 data Config
   = Config
   { configUsername :: Text
   , configHostname :: Text
-  , configTeam     :: Text
+  , configTeam     :: UserText
   , configPort     :: Int
   , configPassword :: Text
   }

--- a/examples/GetPosts.hs
+++ b/examples/GetPosts.hs
@@ -32,7 +32,7 @@ import           LocalConfig -- You will need to define a function:
 
 data Options
   = Options
-  { optChannel :: T.Text
+  { optChannel :: UserText
   , optVerbose :: Bool
   , optOffset  :: Int
   , optLimit   :: Int
@@ -41,7 +41,7 @@ data Options
 
 defaultOptions :: Options
 defaultOptions = Options
-  { optChannel = "town-square"
+  { optChannel = UserText "town-square"
   , optVerbose = False
   , optOffset  = 0
   , optLimit   = 10
@@ -52,7 +52,7 @@ options :: [ OptDescr (Options -> IO Options) ]
 options =
   [ Option "c" ["channel"]
       (ReqArg
-        (\arg opt -> return opt { optChannel = T.pack arg })
+        (\arg opt -> return opt { optChannel = UserText . T.pack $ arg })
         "CHANNEL")
       "Channel to fetch posts from"
   , Option "v" ["verbose"]
@@ -139,5 +139,5 @@ main = do
                pPrint p
             let message = printf "%s: %s"
                                  (userUsername user)
-                                 (postMessage p)
+                                 (unsafeUserText . postMessage $ p)
             putStrLn message

--- a/examples/LocalConfig.hs
+++ b/examples/LocalConfig.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LocalConfig where
 import           Config
 import           System.Process ( readProcess )
 import qualified Data.Text as T
+import           Network.Mattermost.Types ( UserText (..) )
 
 getConfig :: IO Config
 getConfig = do
@@ -9,9 +11,9 @@ getConfig = do
   let cmd = words "pass ldap"
   pass <- takeWhile (/='\n') <$> readProcess (head cmd) (tail cmd) ""
   return $ Config
-         { configUsername = T.pack "USERNAME"
-         , configHostname = T.pack "mattermost.example.com"
-         , configTeam     = T.pack "TEAMNAME"
+         { configUsername = "USERNAME"
+         , configHostname = "mattermost.example.com"
+         , configTeam     = UserText "TEAMNAME"
          , configPort     = 443 -- currently we only support HTTPS
          , configPassword = T.pack pass
          }

--- a/examples/MakePost.hs
+++ b/examples/MakePost.hs
@@ -30,14 +30,14 @@ import           LocalConfig -- You will need to define a function:
 
 data Options
   = Options
-  { optChannel :: T.Text
+  { optChannel :: UserText
   , optVerbose :: Bool
   , optMessage :: T.Text
   } deriving (Read, Show)
 
 defaultOptions :: Options
 defaultOptions = Options
-  { optChannel = "town-square"
+  { optChannel = UserText "town-square"
   , optVerbose = False
   , optMessage = ""
   }
@@ -46,7 +46,7 @@ options :: [ OptDescr (Options -> IO Options) ]
 options =
   [ Option "c" ["channel"]
       (ReqArg
-        (\arg opt -> return opt { optChannel = T.pack arg })
+        (\arg opt -> return opt { optChannel = UserText . T.pack $ arg })
         "CHANNEL")
       "Channel to fetch posts from"
   , Option "v" ["verbose"]


### PR DESCRIPTION
Hey @jtdaugherty, in #46 I missed the examples. Sorry about multiple PRs, could've been just one :)