### PR TITLE
Prefix requests with server subdirectory

### DIFF
--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -63,6 +63,7 @@ library
                      , HTTP
                      , http-media
                      , network-uri
+                     , modern-uri
                      , text
                      , time
                      , unordered-containers

--- a/src/Network/Mattermost/Connection.hs
+++ b/src/Network/Mattermost/Connection.hs
@@ -102,7 +102,7 @@ submitRequest :: ConnectionData
               -> B.ByteString
               -> IO HTTP.Response_String
 submitRequest cd mToken method uri payload = do
-  path <- mmPath (cdDirectory cd ++ "/api/v4" ++ uri)
+  path <- mmPath (cdUrlPath cd ++ "/api/v4" ++ uri)
   let contentLength = B.length payload
       authHeader =
           case mToken of

--- a/src/Network/Mattermost/Connection.hs
+++ b/src/Network/Mattermost/Connection.hs
@@ -102,7 +102,8 @@ submitRequest :: ConnectionData
               -> B.ByteString
               -> IO HTTP.Response_String
 submitRequest cd mToken method uri payload = do
-  path <- mmPath (buildPath cd uri)
+  path <- buildPath cd (T.pack uri)
+  parsedPath <- mmPath $ T.unpack path
   let contentLength = B.length payload
       authHeader =
           case mToken of
@@ -110,7 +111,7 @@ submitRequest cd mToken method uri payload = do
               Just token -> [HTTP.mkHeader HTTP.HdrAuthorization ("Bearer " ++ getTokenString token)]
 
       request = HTTP.Request
-        { HTTP.rqURI = path
+        { HTTP.rqURI = parsedPath
         , HTTP.rqMethod = method
         , HTTP.rqHeaders =
           authHeader <>

--- a/src/Network/Mattermost/Connection.hs
+++ b/src/Network/Mattermost/Connection.hs
@@ -102,7 +102,7 @@ submitRequest :: ConnectionData
               -> B.ByteString
               -> IO HTTP.Response_String
 submitRequest cd mToken method uri payload = do
-  path <- mmPath (cdUrlPath cd ++ "/api/v4" ++ uri)
+  path <- mmPath (buildPath cd uri)
   let contentLength = B.length payload
       authHeader =
           case mToken of

--- a/src/Network/Mattermost/Connection.hs
+++ b/src/Network/Mattermost/Connection.hs
@@ -102,7 +102,7 @@ submitRequest :: ConnectionData
               -> B.ByteString
               -> IO HTTP.Response_String
 submitRequest cd mToken method uri payload = do
-  path <- mmPath ("/api/v4" ++ uri)
+  path <- mmPath (cdDirectory cd ++ "/api/v4" ++ uri)
   let contentLength = B.length payload
       authHeader =
           case mToken of

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -68,10 +68,11 @@ maybeFail :: Parser a -> Parser (Maybe a)
 maybeFail p = (Just <$> p) <|> (return Nothing)
 
 -- | Creates a structure representing a connection to the server.
-mkConnectionData :: Hostname -> Port -> Pool.Pool MMConn -> ConnectionType -> ConnectionContext -> ConnectionData
-mkConnectionData host port pool connTy ctx = ConnectionData
+mkConnectionData :: Hostname -> Port -> String -> Pool.Pool MMConn -> ConnectionType -> ConnectionContext -> ConnectionData
+mkConnectionData host port dir pool connTy ctx = ConnectionData
   { cdHostname       = host
   , cdPort           = port
+  , cdDirectory      = dir
   , cdConnectionCtx  = ctx
   , cdAutoClose      = No
   , cdConnectionPool = pool
@@ -85,11 +86,11 @@ createPool host port ctx cpc connTy =
   Pool.createPool (mkConnection ctx host port connTy >>= newMMConn) closeMMConn
                   (cpStripesCount cpc) (cpIdleConnTimeout cpc) (cpMaxConnCount cpc)
 
-initConnectionData :: Hostname -> Port -> ConnectionType -> ConnectionPoolConfig -> IO ConnectionData
-initConnectionData host port connTy cpc = do
+initConnectionData :: Hostname -> Port -> String -> ConnectionType -> ConnectionPoolConfig -> IO ConnectionData
+initConnectionData host port dir connTy cpc = do
   ctx  <- initConnectionContext
   pool <- createPool host port ctx cpc connTy
-  return (mkConnectionData host port pool connTy ctx)
+  return (mkConnectionData host port dir pool connTy ctx)
 
 destroyConnectionData :: ConnectionData -> IO ()
 destroyConnectionData = Pool.destroyAllResources . cdConnectionPool

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -68,7 +68,7 @@ maybeFail :: Parser a -> Parser (Maybe a)
 maybeFail p = (Just <$> p) <|> (return Nothing)
 
 -- | Creates a structure representing a connection to the server.
-mkConnectionData :: Hostname -> Port -> String -> Pool.Pool MMConn -> ConnectionType -> ConnectionContext -> ConnectionData
+mkConnectionData :: Hostname -> Port -> T.Text -> Pool.Pool MMConn -> ConnectionType -> ConnectionContext -> ConnectionData
 mkConnectionData host port path pool connTy ctx = ConnectionData
   { cdHostname       = host
   , cdPort           = port
@@ -86,7 +86,7 @@ createPool host port ctx cpc connTy =
   Pool.createPool (mkConnection ctx host port connTy >>= newMMConn) closeMMConn
                   (cpStripesCount cpc) (cpIdleConnTimeout cpc) (cpMaxConnCount cpc)
 
-initConnectionData :: Hostname -> Port -> String -> ConnectionType -> ConnectionPoolConfig -> IO ConnectionData
+initConnectionData :: Hostname -> Port -> T.Text -> ConnectionType -> ConnectionPoolConfig -> IO ConnectionData
 initConnectionData host port path connTy cpc = do
   ctx  <- initConnectionContext
   pool <- createPool host port ctx cpc connTy

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -69,10 +69,10 @@ maybeFail p = (Just <$> p) <|> (return Nothing)
 
 -- | Creates a structure representing a connection to the server.
 mkConnectionData :: Hostname -> Port -> String -> Pool.Pool MMConn -> ConnectionType -> ConnectionContext -> ConnectionData
-mkConnectionData host port dir pool connTy ctx = ConnectionData
+mkConnectionData host port path pool connTy ctx = ConnectionData
   { cdHostname       = host
   , cdPort           = port
-  , cdDirectory      = dir
+  , cdUrlPath        = path
   , cdConnectionCtx  = ctx
   , cdAutoClose      = No
   , cdConnectionPool = pool
@@ -87,10 +87,10 @@ createPool host port ctx cpc connTy =
                   (cpStripesCount cpc) (cpIdleConnTimeout cpc) (cpMaxConnCount cpc)
 
 initConnectionData :: Hostname -> Port -> String -> ConnectionType -> ConnectionPoolConfig -> IO ConnectionData
-initConnectionData host port dir connTy cpc = do
+initConnectionData host port path connTy cpc = do
   ctx  <- initConnectionContext
   pool <- createPool host port ctx cpc connTy
-  return (mkConnectionData host port dir pool connTy ctx)
+  return (mkConnectionData host port path pool connTy ctx)
 
 destroyConnectionData :: ConnectionData -> IO ()
 destroyConnectionData = Pool.destroyAllResources . cdConnectionPool

--- a/src/Network/Mattermost/Types/Internal.hs
+++ b/src/Network/Mattermost/Types/Internal.hs
@@ -83,6 +83,7 @@ data ConnectionData
   = ConnectionData
   { cdHostname       :: Hostname
   , cdPort           :: Port
+  , cdDirectory      :: String
   , cdAutoClose      :: AutoClose
   , cdConnectionPool :: Pool MMConn
   , cdConnectionCtx  :: C.ConnectionContext

--- a/src/Network/Mattermost/Types/Internal.hs
+++ b/src/Network/Mattermost/Types/Internal.hs
@@ -18,6 +18,7 @@ import Network.HTTP.Headers (Header, HeaderName(..), mkHeader)
 import qualified Network.HTTP.Stream as HTTP
 import qualified Data.ByteString.Char8 as B
 import Network.Mattermost.Types.Base
+import qualified Data.Text as T
 
 data Token = Token String
   deriving (Read, Show, Eq, Ord)
@@ -83,7 +84,7 @@ data ConnectionData
   = ConnectionData
   { cdHostname       :: Hostname
   , cdPort           :: Port
-  , cdUrlPath        :: String
+  , cdUrlPath        :: T.Text
   , cdAutoClose      :: AutoClose
   , cdConnectionPool :: Pool MMConn
   , cdConnectionCtx  :: C.ConnectionContext

--- a/src/Network/Mattermost/Types/Internal.hs
+++ b/src/Network/Mattermost/Types/Internal.hs
@@ -83,7 +83,7 @@ data ConnectionData
   = ConnectionData
   { cdHostname       :: Hostname
   , cdPort           :: Port
-  , cdDirectory      :: String
+  , cdUrlPath        :: String
   , cdAutoClose      :: AutoClose
   , cdConnectionPool :: Pool MMConn
   , cdConnectionCtx  :: C.ConnectionContext

--- a/src/Network/Mattermost/Util.hs
+++ b/src/Network/Mattermost/Util.hs
@@ -17,6 +17,7 @@ import           Control.Exception (finally, onException)
 import           Data.Char ( toUpper )
 import qualified Data.ByteString.Char8 as B
 import qualified Data.Text as T
+import qualified Text.URI as URI
 
 import           Control.Exception ( Exception
                                    , throwIO )
@@ -117,6 +118,9 @@ connectionGetExact con n = loop B.empty 0
             next <- connectionGet con (n - y)
             loop (B.append bs next) (y + (B.length next))
 
--- | Build a full URL path from the path of an API endpoint
-buildPath :: ConnectionData -> String -> String
-buildPath cd endpoint = cdUrlPath cd ++ "/api/v4" ++ endpoint
+-- | Build a full URI path from the path of an API endpoint
+buildPath :: ConnectionData -> T.Text -> IO T.Text
+buildPath cd endpoint = do
+  let rawPath = "/" <> (T.dropWhile (=='/') $ cdUrlPath cd <> "/api/v4/" <> endpoint)
+  uri <- URI.mkURI rawPath
+  return $ URI.render uri

--- a/src/Network/Mattermost/Util.hs
+++ b/src/Network/Mattermost/Util.hs
@@ -10,6 +10,7 @@ module Network.Mattermost.Util
 , withConnection
 , mkConnection
 , connectionGetExact
+, buildPath
 ) where
 
 import           Control.Exception (finally, onException)
@@ -115,3 +116,7 @@ connectionGetExact con n = loop B.empty 0
           | otherwise = do
             next <- connectionGet con (n - y)
             loop (B.append bs next) (y + (B.length next))
+
+-- | Build a full URL path from the path of an API endpoint
+buildPath :: ConnectionData -> String -> String
+buildPath cd endpoint = cdUrlPath cd ++ "/api/v4" ++ endpoint

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -164,7 +164,7 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
         body (MMWS c health) `catch` propagate [mId, pId]
   WS.runClientWithStream stream
                       (T.unpack $ cdHostname cd)
-                      "/api/v4/websocket"
+                      (cdDirectory cd ++ "/api/v4/websocket")
                       WS.defaultConnectionOptions { WS.connectionOnPong = onPong }
                       [ ("Authorization", "Bearer " <> B.pack tk) ]
                       action

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -164,7 +164,7 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
         body (MMWS c health) `catch` propagate [mId, pId]
   WS.runClientWithStream stream
                       (T.unpack $ cdHostname cd)
-                      (cdDirectory cd ++ "/api/v4/websocket")
+                      (cdUrlPath cd ++ "/api/v4/websocket")
                       WS.defaultConnectionOptions { WS.connectionOnPong = onPong }
                       [ ("Authorization", "Bearer " <> B.pack tk) ]
                       action

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -162,9 +162,10 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
                 )
           recv val
         body (MMWS c health) `catch` propagate [mId, pId]
+  path <- buildPath cd "/websocket"
   WS.runClientWithStream stream
                       (T.unpack $ cdHostname cd)
-                      (buildPath cd "/websocket")
+                      (T.unpack path)
                       WS.defaultConnectionOptions { WS.connectionOnPong = onPong }
                       [ ("Authorization", "Bearer " <> B.pack tk) ]
                       action

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -164,7 +164,7 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
         body (MMWS c health) `catch` propagate [mId, pId]
   WS.runClientWithStream stream
                       (T.unpack $ cdHostname cd)
-                      (cdUrlPath cd ++ "/api/v4/websocket")
+                      (buildPath cd "/websocket")
                       WS.defaultConnectionOptions { WS.connectionOnPong = onPong }
                       [ ("Authorization", "Bearer " <> B.pack tk) ]
                       action


### PR DESCRIPTION
These changes make requests and websocket connections possible when the Mattermost API endpoints are relative to some subdirectory. This is not backwards compatible, since it adds another argument to `initConnectionData`. I am also preparing a pull request to Matterhorn which, along with this one, should solve matterhorn-chat/matterhorn#538.