### PR TITLE
Fix haddock syntax error

### DIFF
--- a/src/Network/Mattermost/Util.hs
+++ b/src/Network/Mattermost/Util.hs
@@ -90,7 +90,7 @@ mkConnection ctx host port connTy = do
         ConnectHTTP -> Nothing
         ConnectHTTPS requireTrustedCert ->
             -- The first argument to TLSSettingsSimple is whether to
-            -- *disable* cert validation. If requireTrustedCert is True,
+            -- /disable/ cert validation. If requireTrustedCert is True,
             -- we want that argument to be False to force validation.
             Just (TLSSettingsSimple (not requireTrustedCert) False False)
     , connectionUseSocks  = do


### PR DESCRIPTION
In haddock, // is used for emphasis and * are used for sections and bulleted lists.
Unfortunately this comment was causing a parse error during documentation generation.