### PR TITLE
Add mmGetLimitedClientConfiguration

### DIFF
--- a/src/Network/Mattermost/Endpoints.hs
+++ b/src/Network/Mattermost/Endpoints.hs
@@ -1003,6 +1003,13 @@ mmGetClientConfiguration :: Maybe Text -> Session -> IO ClientConfig
 mmGetClientConfiguration format =
   inGet (printf "/config/client?%s" (mkQueryString [ sequence ("format", fmap T.unpack format) ])) noBody jsonResponse
 
+-- | Limited version of 'mmGetClientConfiguration' that doesn't need a session ID.
+mmGetLimitedClientConfiguration :: ConnectionData -> IO LimitedClientConfig
+mmGetLimitedClientConfiguration cd =
+  doUnauthRequest cd HTTP.GET url noBody >>= jsonResponse
+  where
+    url = printf "/config/client?%s" (mkQueryString [sequence ("format", Just "old")])
+
 -- -- | Reload the configuration file to pick up on any changes made to it.
 -- --
 -- --   /Permissions/: Must have @manage_system@ permission.

--- a/src/Network/Mattermost/Types/Config.hs
+++ b/src/Network/Mattermost/Types/Config.hs
@@ -282,6 +282,24 @@ data ClientConfig = ClientConfig
   , clientConfigDiagnosticsEnabled :: T.Text
   } deriving (Read, Show, Eq)
 
+data LimitedClientConfig = LimitedClientConfig
+  { limitedClientConfigVersion :: T.Text
+  , limitedClientConfigBuildNumber :: T.Text
+  , limitedClientConfigBuildDate :: T.Text
+  , limitedClientConfigBuildHash :: T.Text
+  , limitedClientConfigBuildHashEnterprise :: T.Text
+  , limitedClientConfigBuildEnterpriseReady :: T.Text
+  } deriving (Read, Show, Eq)
+
+instance A.FromJSON LimitedClientConfig where
+  parseJSON = A.withObject "LimitedClientConfig" $ \o -> do
+    limitedClientConfigVersion              <- o A..: "Version"
+    limitedClientConfigBuildNumber          <- o A..: "BuildNumber"
+    limitedClientConfigBuildDate            <- o A..: "BuildDate"
+    limitedClientConfigBuildHash            <- o A..: "BuildHash"
+    limitedClientConfigBuildHashEnterprise  <- o A..: "BuildHashEnterprise"
+    limitedClientConfigBuildEnterpriseReady <- o A..: "BuildEnterpriseReady"
+    return LimitedClientConfig { .. }
 
 instance A.FromJSON ClientConfig where
   parseJSON = A.withObject "ClientConfig" $ \o -> do


### PR DESCRIPTION
This endpoint can be called to get configuration information about an API server without having a valid session ID

This PR is in support for adding API URL detection to matterhorn