### PR TITLE
Use v4 API for /users/me

### DIFF
--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -560,9 +560,9 @@ mmGetProfilesForDMList sess teamid =
     printf "/api/v3/users/profiles_for_dm_list/%s" (idString teamid)
 
 -- |
--- route: @\/api\/v3\/users\/me@
+-- route: @\/api\/v4\/users\/me@
 mmGetMe :: Session -> IO User
-mmGetMe sess = mmDoRequest sess "mmGetMe" "/api/v3/users/me"
+mmGetMe sess = mmDoRequest sess "mmGetMe" "/api/v4/users/me"
 
 -- |
 -- route: @\/api\/v3\/teams\/{team_id}\/users\/{offset}\/{limit}@


### PR DESCRIPTION
The v3 API has been deprecated since January 2018 and is not offered by
(some?) current instances anymore.

`mmGetMe` is not (currently) used by mattermost, but I stumbled upon this while working on token authentification (hopefully coming as a PR soon as well).