### PR TITLE
WebSocket: parse channel_member_updated event

### DIFF
--- a/src/Network/Mattermost/WebSocket/Types.hs
+++ b/src/Network/Mattermost/WebSocket/Types.hs
@@ -208,6 +208,7 @@ data WEData = WEData
   , wepReaction           :: Maybe Reaction
   , wepMentions           :: Maybe (Set UserId)
   , wepPreferences        :: Maybe (Seq Preference)
+  , wepChannelMember      :: Maybe ChannelMember
   } deriving (Read, Show, Eq)
 
 instance FromJSON WEData where
@@ -235,6 +236,10 @@ instance FromJSON WEData where
     wepPreferences <- case wepPreferencesRaw of
       Just str -> fromValueString str
       Nothing  -> return Nothing
+    wepChannelMemberRaw <- o .:? "channelMember"
+    wepChannelMember <- case wepChannelMemberRaw of
+      Just str -> fromValueString str
+      Nothing  -> return Nothing
     return WEData { .. }
 
 instance ToJSON WEData where
@@ -248,6 +253,7 @@ instance ToJSON WEData where
     , "reaction"     .= wepReaction
     , "mentions"     .= toValueString wepMentions
     , "preferences"  .= toValueString wepPreferences
+    , "channelMember" .= toValueString wepChannelMember
     ]
 
 --

--- a/src/Network/Mattermost/WebSocket/Types.hs
+++ b/src/Network/Mattermost/WebSocket/Types.hs
@@ -219,27 +219,12 @@ instance FromJSON WEData where
     wepUserId             <- o .:? "user_id"
     wepUser               <- o .:? "user"
     wepChannelDisplayName <- o .:? "channel_name"
-    wepPostRaw            <- o .:? "post"
-    wepPost <- case wepPostRaw of
-      Just str -> fromValueString str
-      Nothing  -> return Nothing
-    wepStatus <- o .:? "status"
-    wepReactionRaw <- o .:? "reaction"
-    wepReaction <- case wepReactionRaw of
-      Just str -> fromValueString str
-      Nothing  -> return Nothing
-    wepMentionsRaw <- o .:? "mentions"
-    wepMentions <- case wepMentionsRaw of
-      Just str -> fromValueString str
-      Nothing  -> return Nothing
-    wepPreferencesRaw <- o .:? "preferences"
-    wepPreferences <- case wepPreferencesRaw of
-      Just str -> fromValueString str
-      Nothing  -> return Nothing
-    wepChannelMemberRaw <- o .:? "channelMember"
-    wepChannelMember <- case wepChannelMemberRaw of
-      Just str -> fromValueString str
-      Nothing  -> return Nothing
+    wepPost               <- mapM fromValueString =<< o .:? "post"
+    wepStatus             <- o .:? "status"
+    wepReaction           <- mapM fromValueString =<< o .:? "reaction"
+    wepMentions           <- mapM fromValueString =<< o .:? "mentions"
+    wepPreferences        <- mapM fromValueString =<< o .:? "preferences"
+    wepChannelMember      <- mapM fromValueString =<< o .:? "channelMember"
     return WEData { .. }
 
 instance ToJSON WEData where

--- a/src/Network/Mattermost/WebSocket/Types.hs
+++ b/src/Network/Mattermost/WebSocket/Types.hs
@@ -70,6 +70,7 @@ data WebsocketEventType
   | WMReactionRemoved
   | WMChannelViewed
   | WMChannelUpdated
+  | WMChannelMemberUpdated
   | WMEmojiAdded
   | WMUserRoleUpdated
   | WMPluginStatusesChanged
@@ -106,6 +107,7 @@ instance FromJSON WebsocketEventType where
     "preferences_deleted" -> return WMPreferenceDeleted
     "channel_viewed"     -> return WMChannelViewed
     "channel_updated"    -> return WMChannelUpdated
+    "channel_member_updated" -> return WMChannelMemberUpdated
     "emoji_added"        -> return WMEmojiAdded
     "user_role_updated"  -> return WMUserRoleUpdated
     "plugin_statuses_changed" -> return WMPluginStatusesChanged
@@ -141,6 +143,7 @@ instance ToJSON WebsocketEventType where
   toJSON WMAuthenticationChallenge = "authentication_challenge"
   toJSON WMChannelViewed           = "channel_viewed"
   toJSON WMChannelUpdated          = "channel_updated"
+  toJSON WMChannelMemberUpdated    = "channel_member_updated"
   toJSON WMEmojiAdded              = "emoji_added"
   toJSON WMUserRoleUpdated         = "user_role_updated"
   toJSON WMPluginStatusesChanged   = "plugin_statuses_changed"


### PR DESCRIPTION
The server sends this event when a user updates their preferences, so this is necessary for matterhorn-chat/matterhorn#582.