### PR TITLE
Stop converting back to JSON before logging

### DIFF
--- a/src/Network/Mattermost.hs
+++ b/src/Network/Mattermost.hs
@@ -219,7 +219,7 @@ mmLogin cd login = do
   let rawPath = "/api/v3/users/login"
   path <- mmPath rawPath
   runLogger cd "mmLogin" $
-    HttpRequest GET rawPath (Just (toJSON $ login { password = "<elided>" }))
+    HttpRequest GET rawPath (Just (show $ login { password = "<elided>" }))
   rsp  <- mmUnauthenticatedHTTPPost cd path login
   if (rspCode rsp /= (2,0,0))
     then do
@@ -229,7 +229,7 @@ mmLogin cd login = do
       token <- mmGetHeader   rsp (HdrCustom "Token")
       (raw, value) <- mmGetJSONBody "User" rsp
       runLogger cd "mmLogin" $
-        HttpResponse 200 rawPath (Just raw)
+        HttpResponse 200 rawPath (Just $ show raw)
       return (Right (Session cd (Token token), value))
 
 showRespCode :: (Int, Int, Int) -> String
@@ -257,11 +257,11 @@ mmCreateTeam sess payload = do
   let path = "/api/v3/teams/create"
   uri <- mmPath path
   runLoggerS sess "mmCreateTeam" $
-    HttpRequest POST path (Just (toJSON payload))
+    HttpRequest POST path (Just $ show payload)
   rsp <- mmPOST sess uri payload
   (val, r) <- mmGetJSONBody "Team" rsp
   runLoggerS sess "mmCreateTeam" $
-    HttpResponse 200 path (Just val)
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- | Requires an authenticated user. Returns the full list of channels
@@ -346,7 +346,7 @@ mmViewChannel sess teamid chanid previd = do
       payload = HM.fromList $ [("channel_id" :: T.Text, chanid)] ++ prev
   uri <- mmPath path
   runLoggerS sess "mmViewChannel" $
-    HttpRequest POST path (Just (toJSON payload))
+    HttpRequest POST path (Just $ show payload)
   _ <- mmPOST sess uri payload
   runLoggerS sess "mmViewChannel" $
     HttpResponse 200 path Nothing
@@ -368,7 +368,7 @@ mmJoinChannel sess teamid chanid = do
   rsp <- mmPOST sess uri (""::T.Text)
   (val, (_::Channel)) <- mmGetJSONBody "Channel" rsp
   runLoggerS sess "mmJoinChannel" $
-    HttpResponse 200 path (Just val)
+    HttpResponse 200 path (Just $ show val)
   return ()
 
 -- |
@@ -384,11 +384,11 @@ mmLeaveChannel sess teamid chanid = do
       payload = HM.fromList [("id" :: T.Text, chanid)]
   uri <- mmPath path
   runLoggerS sess "mmLeaveChannel" $
-    HttpRequest POST path (Just (toJSON payload))
+    HttpRequest POST path (Just $ show payload)
   rsp <- mmPOST sess uri payload
   (val, (_::HM.HashMap T.Text ChannelId)) <- mmGetJSONBody "Channel name/ID map" rsp
   runLoggerS sess "mmCreateDirect" $
-    HttpResponse 200 path (Just val)
+    HttpResponse 200 path (Just $ show val)
   return ()
 
 -- |
@@ -437,7 +437,7 @@ mmGetPost sess teamid chanid postid = do
   rsp <- mmRequest sess uri
   (raw, json) <- mmGetJSONBody "Posts" rsp
   runLoggerS sess "mmGetPost" $
-    HttpResponse 200 path (Just raw)
+    HttpResponse 200 path (Just $ show raw)
   return json
 
 -- |
@@ -488,11 +488,11 @@ mmSearchPosts sess teamid terms isOrSearch = do
   uri <- mmPath path
   let req = SearchPosts terms isOrSearch
   runLoggerS sess "mmSearchPosts" $
-    HttpRequest POST path (Just (toJSON req))
+    HttpRequest POST path (Just $ show req)
   rsp <- mmPOST sess uri req
   (raw, value) <- mmGetJSONBody "SearchPostsResult" rsp
   runLoggerS sess "mmSearchPosts" $
-    HttpResponse 200 path (Just raw)
+    HttpResponse 200 path (Just $ show raw)
   return value
 
 -- |
@@ -591,11 +591,11 @@ mmCreateDirect sess teamid userid = do
       payload = HM.fromList [("user_id" :: T.Text, userid)]
   uri <- mmPath path
   runLoggerS sess "mmCreateDirect" $
-    HttpRequest POST path (Just (toJSON payload))
+    HttpRequest POST path (Just $ show payload)
   rsp <- mmPOST sess uri payload
   (val, r) <- mmGetJSONBody "Channel" rsp
   runLoggerS sess "mmCreateDirect" $
-    HttpResponse 200 path (Just val)
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- { name, display_name, purpose, header }
@@ -606,11 +606,11 @@ mmCreateChannel sess teamid payload = do
   let path = printf "/api/v3/teams/%s/channels/create" (idString teamid)
   uri <- mmPath path
   runLoggerS sess "mmCreateChannel" $
-    HttpRequest POST path (Just (toJSON payload))
+    HttpRequest POST path (Just $ show payload)
   rsp <- mmPOST sess uri payload
   (val, r) <- mmGetJSONBody "Channel" rsp
   runLoggerS sess "mmCreateChannel" $
-    HttpResponse 200 path (Just val)
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- |
@@ -661,11 +661,11 @@ mmUpdatePost sess teamid post = do
                       (idString chanid)
   uri <- mmPath path
   runLoggerS sess "mmUpdatePost" $
-    HttpRequest POST path (Just (toJSON post))
+    HttpRequest POST path (Just (show post))
   rsp <- mmPOST sess uri post
   (val, r) <- mmGetJSONBody "Post" rsp
   runLoggerS sess "mmUpdatePost" $
-    HttpResponse 200 path (Just (val))
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- |
@@ -681,11 +681,11 @@ mmPost sess teamid post = do
                       (idString chanid)
   uri <- mmPath path
   runLoggerS sess "mmPost" $
-    HttpRequest POST path (Just (toJSON post))
+    HttpRequest POST path (Just $ show post)
   rsp <- mmPOST sess uri post
   (val, r) <- mmGetJSONBody "Post" rsp
   runLoggerS sess "mmPost" $
-    HttpResponse 200 path (Just (val))
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- | Get the system configuration. Requires administrative permission.
@@ -713,7 +713,7 @@ mmSaveConfig sess config = do
   let path = "/api/v3/admin/save_config"
   uri <- mmPath path
   runLoggerS sess "mmSaveConfig" $
-    HttpRequest POST path (Just config)
+    HttpRequest POST path (Just $ show config)
   _ <- mmPOST sess uri config
   runLoggerS sess "mmSaveConfig" $
     HttpResponse 200 path Nothing
@@ -733,11 +733,11 @@ mmChannelAddUser sess teamid chanId uId = do
       req = object ["user_id" .= uId]
   uri <- mmPath path
   runLoggerS sess "mmChannelAddUser" $
-    HttpRequest POST path (Just req)
+    HttpRequest POST path (Just $ show req)
   rsp <- mmPOST sess uri req
   (val, r) <- mmGetJSONBody "ChannelData" rsp
   runLoggerS sess "mmChannelAddUser" $
-    HttpResponse 200 path (Just val)
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- |
@@ -752,7 +752,7 @@ mmTeamAddUser sess teamid uId = do
       req  = object ["user_id" .= uId]
   uri <- mmPath path
   runLoggerS sess "mmTeamAddUser" $
-    HttpRequest POST path (Just req)
+    HttpRequest POST path (Just $ show req)
   _ <- mmPOST sess uri req
   runLoggerS sess "mmTeamAddUSer" $
     HttpResponse 200 path Nothing
@@ -769,11 +769,11 @@ mmExecute sess teamid command = do
                       (idString teamid)
   uri <- mmPath path
   runLoggerS sess "mmExecute" $
-    HttpRequest POST path (Just (toJSON command))
+    HttpRequest POST path (Just $ show command)
   rsp <- mmPOST sess uri command
   (val, r) <- mmGetJSONBody "Value" rsp
   runLoggerS sess "mmExecute" $
-    HttpResponse 200 path (Just (val))
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- |
@@ -785,11 +785,11 @@ mmUsersCreate cd usersCreate = do
   let path = "/api/v3/users/create"
   uri <- mmPath path
   runLogger cd "mmUsersCreate" $
-    HttpRequest POST path (Just (toJSON usersCreate))
+    HttpRequest POST path (Just $ show usersCreate)
   rsp <- mmUnauthenticatedHTTPPost cd uri usersCreate
   (val, r) <- mmGetJSONBody "User" rsp
   runLogger cd "mmUsersCreate" $
-    HttpResponse 200 path (Just (val))
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- |
@@ -801,11 +801,11 @@ mmUsersCreateWithSession sess usersCreate = do
   let path = "/api/v3/users/create"
   uri <- mmPath path
   runLoggerS sess "mmUsersCreateWithToken" $
-    HttpRequest POST path (Just (toJSON usersCreate))
+    HttpRequest POST path (Just $ show usersCreate)
   rsp <- mmPOST sess uri usersCreate
   (val, r) <- mmGetJSONBody "User" rsp
   runLoggerS sess "mmUsersCreateWithToken" $
-    HttpResponse 200 path (Just (val))
+    HttpResponse 200 path (Just $ show val)
   return r
 
 -- |
@@ -869,7 +869,7 @@ mmFlagPost sess uId pId = do
           }
   let rawPath = "/api/v3/preferences/save"
   runLoggerS sess "mmFlagPost" $
-    HttpRequest POST rawPath (Just (toJSON [flaggedPost]))
+    HttpRequest POST rawPath (Just (show [flaggedPost]))
   uri <- mmPath rawPath
   _ <- mmPOST sess uri (Seq.singleton flaggedPost)
   return ()
@@ -892,7 +892,7 @@ mmUnflagPost sess uId pId = do
           }
   let rawPath = "/api/v3/preferences/delete"
   runLoggerS sess "mmUnflagPost" $
-    HttpRequest POST rawPath (Just (toJSON [flaggedPost]))
+    HttpRequest POST rawPath (Just (show [flaggedPost]))
   uri <- mmPath rawPath
   _ <- mmPOST sess uri (Seq.singleton flaggedPost)
   return ()
@@ -928,11 +928,11 @@ mmCreateGroupChannel sess@(Session cd _) uIds = do
       fnname = "mmCreateGroupChannel"
   uri <- mmPath path
   runLoggerS sess fnname $
-    HttpRequest POST path (Just (toJSON uIds))
+    HttpRequest POST path (Just $ show uIds)
   rsp <- mmPOST sess uri uIds
   (raw, json) <- mmGetJSONBody fnname rsp
   runLogger cd fnname $
-    HttpResponse 200 path (Just raw)
+    HttpResponse 200 path (Just $ show raw)
   return json
 
 mmDeleteRequest :: Session -> URI -> IO ()
@@ -991,7 +991,7 @@ mmWithRequest sess@(Session cd _) fnname path action = do
   rsp  <- mmRequest sess uri
   (raw,json) <- mmGetJSONBody fnname rsp
   runLogger cd fnname $
-    HttpResponse 200 path (Just raw)
+    HttpResponse 200 path (Just $ show raw)
   action json
 
 mmPOST :: ToJSON t => Session -> URI -> t -> IO Response_String
@@ -1011,7 +1011,7 @@ mmSetChannelHeader sess teamid chanid header = do
   uri <- mmPath path
   let req = SetChannelHeader chanid header
   runLoggerS sess "mmSetChannelHeader" $
-    HttpRequest POST path (Just (toJSON req))
+    HttpRequest POST path (Just (show req))
   rsp <- mmPOST sess uri req
   (_, r) <- mmGetJSONBody "Channel" rsp
   return r

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -306,10 +306,6 @@ instance A.FromJSON NotifyOption where
   parseJSON (A.String "none")    = return NotifyOptionNone
   parseJSON xs                   = fail ("Unknown NotifyOption value: " ++ show xs)
 
-data UserProps = UserProps
-  -- TODO: Figure out what this is
-  deriving (Eq, Show, Read, Ord)
-
 data UserNotifyProps = UserNotifyProps
   { userNotifyPropsMentionKeys  :: [UserText]
   , userNotifyPropsEmail        :: Bool
@@ -580,75 +576,45 @@ instance HasId User UserId where
 
 data User
   = User
-  { userId                     :: UserId
-  , userCreateAt               :: Maybe ServerTime
-  , userUpdateAt               :: Maybe ServerTime
-  , userDeleteAt               :: ServerTime
-  , userUsername               :: Text
-  , userPassword               :: Maybe Text
-  , userAuthData               :: Maybe Text
-  , userAuthService            :: Text
-  , userEmail                  :: UserText
-  , userEmailVerified          :: Bool
-  , userNickname               :: UserText
-  , userFirstName              :: UserText
-  , userLastName               :: UserText
-  , userPosition               :: Text
-  , userRoles                  :: Text
-  , userAllowMarketing         :: Bool
-  -- , userProps                  :: Maybe UserProps
-  , userNotifyProps            :: UserNotifyProps
-  , userLastPasswordUpdate     :: Maybe ServerTime
-  , userLastPictureUpdate      :: Maybe ServerTime
-  , userFailedAttempts         :: Maybe Text
-  , userLocale                 :: Text
-  --, userTimezone               :: Timezone
-  , userMfaActive              :: Bool
-  , userMfaSecret              :: Maybe Text
-  , userLastActivityAt         :: Maybe ServerTime
-  , userIsBot                  :: Bool
-  , userBotDescription         :: Maybe Text
-  , userBotLastIconUpdate      :: Maybe ServerTime
-  , userTermsOfServiceId       :: Maybe Text
-  , userTermsOfServiceCreateAt :: Maybe ServerTime
-
+  { userId                 :: UserId
+  , userCreateAt           :: Maybe ServerTime
+  , userUpdateAt           :: Maybe ServerTime
+  , userDeleteAt           :: ServerTime
+  , userUsername           :: Text
+  , userAuthData           :: Maybe Text
+  , userAuthService        :: Text
+  , userEmail              :: UserText
+  , userEmailVerified      :: Bool
+  , userNickname           :: UserText
+  , userFirstName          :: UserText
+  , userLastName           :: UserText
+  , userRoles              :: Text
+  , userNotifyProps        :: UserNotifyProps
+  , userLastPasswordUpdate :: Maybe ServerTime
+  , userLastPictureUpdate  :: Maybe ServerTime
+  , userLocale             :: Text
   } deriving (Read, Show, Eq)
 
 instance A.FromJSON User where
-  parseJSON = A.withObject "user" $ \o -> do
-    userId                     <- o .: "id"
-    userCreateAt               <- (timeFromServer <$>) <$> o .:? "create_at"
-    userUpdateAt               <- (timeFromServer <$>) <$> o .:? "update_at"
-    userDeleteAt               <- timeFromServer <$> o .: "delete_at"
-    userUsername               <- o .:  "username"
-    userPassword               <- o .:? "password"
-    userAuthData               <- o .:? "auth_data"
-    userAuthService            <- o .:  "auth_service"
-    userEmail                  <- o .:  "email"
-    userEmailVerified          <- o .:? "email_verified" .!= False
-    userNickname               <- o .:  "nickname"
-    userFirstName              <- o .:  "first_name"
-    userLastName               <- o .:  "last_name"
-    userPosition               <- o .:  "position"
-    userRoles                  <- o .:  "roles"
-    userAllowMarketing         <- o .:? "allow_marketing" .!= False
-    -- userProps                  <- o .:? "props"
-    userNotifyProps            <- o .:? "notify_props" .!= emptyUserNotifyProps
-    userLastPasswordUpdate     <- (timeFromServer <$>) <$>
-                                  (o .:? "last_password_update")
-    userLastPictureUpdate      <- (timeFromServer <$>) <$> (o .:? "last_picture_update")
-    userFailedAttempts         <- o .:? "failed_attempts"
-    userLocale                 <- o .:  "locale"
-    -- userTimezone               <- o .:  "timezone"
-    userMfaActive              <- o .:? "mfa_active" .!= False
-    userMfaSecret              <- o .:? "mfa_secret"
-    userLastActivityAt         <- (timeFromServer <$>) <$> (o .:? "last_activity_at")
-    userIsBot                  <- o .:? "is_bot" .!= False
-    userBotDescription         <- o .:? "bot_description"
-    userBotLastIconUpdate      <- (timeFromServer <$>) <$> (o .:? "bot_last_icon_update")
-    userTermsOfServiceId       <- o .:? "terms_of_service_id"
-    userTermsOfServiceCreateAt <- (timeFromServer <$>) <$> (o .:? "terms_of_service_create_at")
-
+  parseJSON = A.withObject "User" $ \o -> do
+    userId                 <- o .: "id"
+    userCreateAt           <- (timeFromServer <$>) <$> o .:? "create_at"
+    userUpdateAt           <- (timeFromServer <$>) <$> o .:? "update_at"
+    userDeleteAt           <- timeFromServer <$> o .: "delete_at"
+    userUsername           <- o .:  "username"
+    userAuthData           <- o .:?  "auth_data"
+    userAuthService        <- o .:  "auth_service"
+    userEmail              <- o .:  "email"
+    userEmailVerified      <- o .:? "email_verified" .!= False
+    userNickname           <- o .:  "nickname"
+    userFirstName          <- o .:  "first_name"
+    userLastName           <- o .:  "last_name"
+    userRoles              <- o .:  "roles"
+    userNotifyProps        <- o .:? "notify_props" .!= emptyUserNotifyProps
+    userLastPasswordUpdate <- (timeFromServer <$>) <$>
+                              (o .:? "last_password_update")
+    userLastPictureUpdate  <- (timeFromServer <$>) <$> (o .:? "last_picture_update")
+    userLocale             <- o .: "locale"
     return User { .. }
 
 

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -306,6 +306,10 @@ instance A.FromJSON NotifyOption where
   parseJSON (A.String "none")    = return NotifyOptionNone
   parseJSON xs                   = fail ("Unknown NotifyOption value: " ++ show xs)
 
+data UserProps = UserProps
+  -- TODO: Figure out what this is
+  deriving (Eq, Show, Read, Ord)
+
 data UserNotifyProps = UserNotifyProps
   { userNotifyPropsMentionKeys  :: [UserText]
   , userNotifyPropsEmail        :: Bool
@@ -576,45 +580,75 @@ instance HasId User UserId where
 
 data User
   = User
-  { userId                 :: UserId
-  , userCreateAt           :: Maybe ServerTime
-  , userUpdateAt           :: Maybe ServerTime
-  , userDeleteAt           :: ServerTime
-  , userUsername           :: Text
-  , userAuthData           :: Maybe Text
-  , userAuthService        :: Text
-  , userEmail              :: UserText
-  , userEmailVerified      :: Bool
-  , userNickname           :: UserText
-  , userFirstName          :: UserText
-  , userLastName           :: UserText
-  , userRoles              :: Text
-  , userNotifyProps        :: UserNotifyProps
-  , userLastPasswordUpdate :: Maybe ServerTime
-  , userLastPictureUpdate  :: Maybe ServerTime
-  , userLocale             :: Text
+  { userId                     :: UserId
+  , userCreateAt               :: Maybe ServerTime
+  , userUpdateAt               :: Maybe ServerTime
+  , userDeleteAt               :: ServerTime
+  , userUsername               :: Text
+  , userPassword               :: Maybe Text
+  , userAuthData               :: Maybe Text
+  , userAuthService            :: Text
+  , userEmail                  :: UserText
+  , userEmailVerified          :: Bool
+  , userNickname               :: UserText
+  , userFirstName              :: UserText
+  , userLastName               :: UserText
+  , userPosition               :: Text
+  , userRoles                  :: Text
+  , userAllowMarketing         :: Bool
+  -- , userProps                  :: Maybe UserProps
+  , userNotifyProps            :: UserNotifyProps
+  , userLastPasswordUpdate     :: Maybe ServerTime
+  , userLastPictureUpdate      :: Maybe ServerTime
+  , userFailedAttempts         :: Maybe Text
+  , userLocale                 :: Text
+  --, userTimezone               :: Timezone
+  , userMfaActive              :: Bool
+  , userMfaSecret              :: Maybe Text
+  , userLastActivityAt         :: Maybe ServerTime
+  , userIsBot                  :: Bool
+  , userBotDescription         :: Maybe Text
+  , userBotLastIconUpdate      :: Maybe ServerTime
+  , userTermsOfServiceId       :: Maybe Text
+  , userTermsOfServiceCreateAt :: Maybe ServerTime
+
   } deriving (Read, Show, Eq)
 
 instance A.FromJSON User where
-  parseJSON = A.withObject "User" $ \o -> do
-    userId                 <- o .: "id"
-    userCreateAt           <- (timeFromServer <$>) <$> o .:? "create_at"
-    userUpdateAt           <- (timeFromServer <$>) <$> o .:? "update_at"
-    userDeleteAt           <- timeFromServer <$> o .: "delete_at"
-    userUsername           <- o .:  "username"
-    userAuthData           <- o .:?  "auth_data"
-    userAuthService        <- o .:  "auth_service"
-    userEmail              <- o .:  "email"
-    userEmailVerified      <- o .:? "email_verified" .!= False
-    userNickname           <- o .:  "nickname"
-    userFirstName          <- o .:  "first_name"
-    userLastName           <- o .:  "last_name"
-    userRoles              <- o .:  "roles"
-    userNotifyProps        <- o .:? "notify_props" .!= emptyUserNotifyProps
-    userLastPasswordUpdate <- (timeFromServer <$>) <$>
-                              (o .:? "last_password_update")
-    userLastPictureUpdate  <- (timeFromServer <$>) <$> (o .:? "last_picture_update")
-    userLocale             <- o .: "locale"
+  parseJSON = A.withObject "user" $ \o -> do
+    userId                     <- o .: "id"
+    userCreateAt               <- (timeFromServer <$>) <$> o .:? "create_at"
+    userUpdateAt               <- (timeFromServer <$>) <$> o .:? "update_at"
+    userDeleteAt               <- timeFromServer <$> o .: "delete_at"
+    userUsername               <- o .:  "username"
+    userPassword               <- o .:? "password"
+    userAuthData               <- o .:? "auth_data"
+    userAuthService            <- o .:  "auth_service"
+    userEmail                  <- o .:  "email"
+    userEmailVerified          <- o .:? "email_verified" .!= False
+    userNickname               <- o .:  "nickname"
+    userFirstName              <- o .:  "first_name"
+    userLastName               <- o .:  "last_name"
+    userPosition               <- o .:  "position"
+    userRoles                  <- o .:  "roles"
+    userAllowMarketing         <- o .:? "allow_marketing" .!= False
+    -- userProps                  <- o .:? "props"
+    userNotifyProps            <- o .:? "notify_props" .!= emptyUserNotifyProps
+    userLastPasswordUpdate     <- (timeFromServer <$>) <$>
+                                  (o .:? "last_password_update")
+    userLastPictureUpdate      <- (timeFromServer <$>) <$> (o .:? "last_picture_update")
+    userFailedAttempts         <- o .:? "failed_attempts"
+    userLocale                 <- o .:  "locale"
+    -- userTimezone               <- o .:  "timezone"
+    userMfaActive              <- o .:? "mfa_active" .!= False
+    userMfaSecret              <- o .:? "mfa_secret"
+    userLastActivityAt         <- (timeFromServer <$>) <$> (o .:? "last_activity_at")
+    userIsBot                  <- o .:? "is_bot" .!= False
+    userBotDescription         <- o .:? "bot_description"
+    userBotLastIconUpdate      <- (timeFromServer <$>) <$> (o .:? "bot_last_icon_update")
+    userTermsOfServiceId       <- o .:? "terms_of_service_id"
+    userTermsOfServiceCreateAt <- (timeFromServer <$>) <$> (o .:? "terms_of_service_create_at")
+
     return User { .. }
 
 -- The PostPropAttachment and PostPropAttachmentField types are

--- a/src/Network/Mattermost/Types.hs
+++ b/src/Network/Mattermost/Types.hs
@@ -44,7 +44,7 @@ import           Network.Connection ( ConnectionContext
                                     )
 import           Network.Mattermost.Types.Base
 import           Network.Mattermost.Types.Internal
-import           Network.Mattermost.Util (mkConnection, ConnectionType(..))
+import           Network.Mattermost.Util ( mkConnection )
 
 newtype UserText = UserText Text
                  deriving (Eq, Show, Ord, Read)
@@ -121,7 +121,7 @@ data Login
   = Login
   { username :: Text
   , password :: Text
-  }
+  } deriving (Show)
 
 instance A.ToJSON Login where
   toJSON l = A.object ["login_id" A..= username l
@@ -132,7 +132,7 @@ instance A.ToJSON Login where
 data SetChannelHeader = SetChannelHeader
   { setChannelHeaderChanId :: ChannelId
   , setChannelHeaderString :: Text
-  }
+  } deriving (Show)
 
 instance A.ToJSON SetChannelHeader where
   toJSON (SetChannelHeader cId p) =
@@ -143,7 +143,7 @@ instance A.ToJSON SetChannelHeader where
 data SearchPosts = SearchPosts
  { searchPostsTerms      :: Text
  , searchPostsIsOrSearch :: Bool
- }
+ } deriving (Show)
 
 instance A.ToJSON SearchPosts where
  toJSON (SearchPosts t os) =
@@ -650,6 +650,7 @@ instance A.FromJSON User where
     userTermsOfServiceCreateAt <- (timeFromServer <$>) <$> (o .:? "terms_of_service_create_at")
 
     return User { .. }
+
 
 -- The PostPropAttachment and PostPropAttachmentField types are
 -- actually defined by Slack, and simply used by Mattermost; the
@@ -1452,7 +1453,6 @@ instance PrintfArg ReportId where
 
 instance A.ToJSON User where toJSON = error "to user"
 instance A.ToJSON Team where toJSON = error "to team"
-
 
 -- --
 

--- a/src/Network/Mattermost/Types/Base.hs
+++ b/src/Network/Mattermost/Types/Base.hs
@@ -25,10 +25,10 @@ data LogEvent = LogEvent
 
 -- | A 'LogEventType' describes the particular event that happened
 data LogEventType
-  = HttpRequest RequestMethod String (Maybe A.Value)
-  | HttpResponse Int String (Maybe A.Value)
+  = HttpRequest RequestMethod String (Maybe String)
+  | HttpResponse Int String (Maybe String)
   | WebSocketRequest A.Value
-  | WebSocketResponse (Either String A.Value)
+  | WebSocketResponse (Either String String)
   -- ^ Left means we got an exception trying to parse the response;
   -- Right means we succeeded and here it is.
   | WebSocketPing

--- a/src/Network/Mattermost/WebSocket.hs
+++ b/src/Network/Mattermost/WebSocket.hs
@@ -126,7 +126,7 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
 
           val <- case result of
                 Left e -> do
-                    doLog $ WebSocketResponse $ Right $ toJSON $
+                    doLog $ WebSocketResponse $ Right $ 
                         "Got exception on receiveDataMessage: " <> show e
                     throwIO e
                 Right dataMsg -> do
@@ -157,8 +157,8 @@ mmWithWebSocket (Session cd (Token tk)) recv body = do
 
           doLog (WebSocketResponse $ case val of
                 Left s -> Left s
-                Right (Left v) -> Right $ toJSON v
-                Right (Right v) -> Right $ toJSON v
+                Right (Left v) -> Right $ show v
+                Right (Right v) -> Right $ show v
                 )
           recv val
         body (MMWS c health) `catch` propagate [mId, pId]


### PR DESCRIPTION
This started as a simple update of the `User` type to match the upstream implementation and corresponding JSON messages, but ultimately also changes the types being logged on websocket events.  This is because the bug I thought I was fixing turned out to be an unfinished implementation of `ToJSON` for some of our types, and so the AESON datatypes that were getting logged didn't match the actual incoming message.  This changes them to be `String`s generated via simple calls to `show`.  The extra level of indirection wasn't really adding anything anyway, and now we don't depend on it being correct and complete.