### PR TITLE
Fix a pattern-match coverage warning in GHC 9.0

### DIFF
--- a/src/Network/Mattermost/Proxy.hs
+++ b/src/Network/Mattermost/Proxy.hs
@@ -36,12 +36,10 @@ proxyHostPermitted hostname = do
                         go [] [] = True
                         go [] _ = False
                         go _ [] = False
-                        go (p:pParts) hParts =
+                        go (p:pParts) (h:hTail) =
                             if p == "*"
                             then True
-                            else case hParts of
-                                [] -> False
-                                (h:hTail) -> p == h && go pParts hTail
+                            else p == h && go pParts hTail
                     in go patParts hostnameParts
             return $ not isBlacklisted
 


### PR DESCRIPTION
Building `mattermost-api` with GHC 9.0 produces the following warning:

```
[ 2 of 17] Compiling Network.Mattermost.Proxy ( src/Network/Mattermost/Proxy.hs, /home/rscott/Documents/Hacking/Haskell/matterhorn/dist-newstyle/build/x86_64-linux/ghc-9.0.1/mattermost-api-50200.11.0/build/Network/Mattermost/Proxy.o, /home/rscott/Documents/Hacking/Haskell/matterhorn/dist-newstyle/build/x86_64-linux/ghc-9.0.1/mattermost-api-50200.11.0/build/Network/Mattermost/Proxy.dyn_o )

src/Network/Mattermost/Proxy.hs:43:33: warning: [-Woverlapping-patterns]
    Pattern match is redundant
    In a case alternative: [] -> ...
   |
43 |                                 [] -> False
   |                                 ^^^^^^^^^^^
```

This is because GHC 9.0's pattern-match coverage checker is smarter and is able to tell that `hParts` has already been matched against `[]`. This patch tweaks the surrounding code to avoid this warning.