### PR TITLE
Support building with `mtl-2.3.*`

### DIFF
--- a/test/Tests/Util.hs
+++ b/test/Tests/Util.hs
@@ -53,13 +53,16 @@ import qualified Control.Exception as E
 import qualified Control.Concurrent.STM as STM
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
+import Control.Monad (join, when)
+import Control.Monad.IO.Class (MonadIO(..))
 import qualified Data.Foldable as F
+import Data.Functor (void)
 import Data.Monoid ((<>))
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (testCaseSteps)
-import Control.Monad.State.Lazy
+import Control.Monad.State.Lazy (evalStateT, gets, modify)
 import System.Timeout (timeout)
 
 import Network.Mattermost (ConnectionData)


### PR DESCRIPTION
`mtl-2.3.*` no longer re-exports `Control.Monad`, `Control.Monad.IO.Class`, or `Control.Monad.Trans.Class` from its various modules. This breaks some of the code in `mattermost-api`'s test suite, so this patch adapts to the change by using explicit imports.

This is a prerequisite to making `mattermost-api` build with GHC 9.6, which bundles `mtl-2.3.1`.