### PR TITLE
Support crypton-connection >= 0.4.0

### DIFF
--- a/mattermost-api.cabal
+++ b/mattermost-api.cabal
@@ -45,7 +45,7 @@ library
                      , websockets >= 0.11.0.0
                      , stm
                      , aeson >= 2.0.1.0 && < 2.3.0.0
-                     , crypton-connection
+                     , crypton-connection >= 0.4.0 && < 0.5.0
                      , memory
                      , resource-pool >= 0.2.3
                      -- To prevent broken websockets versions from using
@@ -69,6 +69,7 @@ library
                      , template-haskell
                      , microlens
                      , microlens-th
+                     , tls
                      -- Only here to make debugging easier
                      , pretty-show
                      , split

--- a/src/Network/Mattermost/Util.hs
+++ b/src/Network/Mattermost/Util.hs
@@ -23,6 +23,7 @@ import           Data.Monoid ((<>))
 import           Control.Exception ( Exception
                                    , throwIO )
 import           Data.Pool (takeResource, putResource, destroyResource)
+import           Network.TLS (defaultSupported)
 import           Network.Connection ( Connection
                                     , ConnectionContext
                                     , ConnectionParams(..)
@@ -95,7 +96,7 @@ mkConnection ctx host port connTy = do
             -- The first argument to TLSSettingsSimple is whether to
             -- /disable/ cert validation. If requireTrustedCert is True,
             -- we want that argument to be False to force validation.
-            Just (TLSSettingsSimple (not requireTrustedCert) False False)
+            Just (TLSSettingsSimple (not requireTrustedCert) False False defaultSupported)
     , connectionUseSocks  = do
         (ty, cHost, cPort) <- proxy
         case ty of


### PR DESCRIPTION
crypton-connection added a non-optional argument to TLSSettingSimple in 0.4.0: https://github.com/kazu-yamamoto/crypton-connection/pull/3 .

This adds this argument, and limit crypton-connection to < 0.5.0 as they consider minor versions as breaking.

Disclaimer: I have no experience in Haskell programming specifically. I'm just trying to fix the matterhorn package for the NixOS distribution. I noticed that running `cabal build` with `--dependencies-only` (which is how this CI does it but not how NixOS builds Haskell packages) somehow works without this change but can't explain why.

I basically copied a fix made for another problem that had the same issue: https://github.com/ndmitchell/hoogle/pull/424/files .

For reference, this is the issue that happens with just running `cabal build`:

```
[ 8 of 17] Compiling Network.Mattermost.Util ( src/Network/Mattermost/Util.hs, dist/build/Network/Mattermost/Util.o, dist/build/Network/Mattermost/Util.dyn_o )
src/Network/Mattermost/Util.hs:98:19: error: [8;;https://errors.haskell.org/messages/GHC-83865GHC-838658;;]
    • Couldn't match expected type ‘TLSSettings’
                  with actual type ‘tls-2.1.8:Network.TLS.Parameters.Supported
                                    -> TLSSettings’
    • Probable cause: ‘TLSSettingsSimple’ is applied to too few arguments
      In the first argument of ‘Just’, namely
        ‘(TLSSettingsSimple (not requireTrustedCert) False False)’
      In the expression:
        Just (TLSSettingsSimple (not requireTrustedCert) False False)
      In a case alternative:
          ConnectHTTPS requireTrustedCert
            -> Just (TLSSettingsSimple (not requireTrustedCert) False False)
   |
98 |             Just (TLSSettingsSimple (not requireTrustedCert) False False)
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```